### PR TITLE
Remove stale time on client components

### DIFF
--- a/src/app/_components/forecast-daily.tsx
+++ b/src/app/_components/forecast-daily.tsx
@@ -18,7 +18,6 @@ export function ForecastDaily() {
   });
 
   const forecastDaily = useQuery({
-    staleTime: 1000 * 60 * 30, // 30 minutes
     queryKey: [location.data, "forecast", "daily"],
     queryFn: async (): Promise<
       WeatherForecastErrorResponse | WeatherForecastDaily

--- a/src/app/_components/forecast-hourly.tsx
+++ b/src/app/_components/forecast-hourly.tsx
@@ -18,7 +18,6 @@ export function ForecastHourly() {
   });
 
   const forecastHourly = useQuery({
-    staleTime: 1000 * 60 * 20, // 20 minutes
     queryKey: [location.data, "forecast", "hourly"],
     queryFn: async (): Promise<
       WeatherForecastErrorResponse | WeatherForecastHourly

--- a/src/app/_components/forecast-now.tsx
+++ b/src/app/_components/forecast-now.tsx
@@ -22,7 +22,6 @@ export function ForecastNow() {
   });
 
   const forecastNow = useQuery({
-    staleTime: 1000 * 60 * 5, // 5 minutes
     queryKey: [location.data, "forecast", "now"],
     queryFn: async (): Promise<
       WeatherForecastErrorResponse | WeatherForecastNow

--- a/src/app/daily/_components/dailyCharts.tsx
+++ b/src/app/daily/_components/dailyCharts.tsx
@@ -128,7 +128,6 @@ export function DailyCharts() {
   });
 
   const forecastDailyCharts = useQuery({
-    staleTime: 1000 * 60 * 20, // 20 minutes
     queryKey: [location.data, "forecast", "daily"],
     queryFn: async (): Promise<
       WeatherForecastErrorResponse | WeatherForecastDailyCharts

--- a/src/app/hourly/_components/hourlyCharts.tsx
+++ b/src/app/hourly/_components/hourlyCharts.tsx
@@ -69,7 +69,6 @@ export function HourlyCharts() {
   });
 
   const forecastHourlyCharts = useQuery({
-    staleTime: 1000 * 60 * 20, // 20 minutes
     queryKey: [location.data, "forecast", "hourly"],
     queryFn: async (): Promise<
       WeatherForecastErrorResponse | WeatherForecastHourlyCharts


### PR DESCRIPTION
Stale time on the client side appears to have stopped loading data entirely when moving between routes. Caching is already implemented on the server so these additional requests will not increase api requests

Fixes #15 